### PR TITLE
Fix: Allow uppercase 'L' in Base58 pattern validation

### DIFF
--- a/src/estimator.rs
+++ b/src/estimator.rs
@@ -10,10 +10,10 @@ pub struct PatternEstimate {
 /// Checks if a character is valid in the Base58 alphabet
 pub fn is_base58_char(c: char) -> bool {
     // Base58 alphabet: 123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz
-    // Excluded: 0, O, I, l
+    // Excluded: 0 (zero), O (uppercase o), I (uppercase i), l (lowercase L)
     match c {
         '0' | 'O' | 'I' | 'l' => false,
-        '1'..='9' | 'A'..='Z' | 'a'..='z' => true,
+        '1'..='9' | 'A'..='H' | 'J'..='N' | 'P'..='Z' | 'a'..='k' | 'm'..='z' => true,
         _ => false,
     }
 }
@@ -34,9 +34,9 @@ pub fn estimate_pattern(pattern: &str, is_start: bool) -> PatternEstimate {
             invalid_chars.push(c);
         }
     }
-    
+
     let has_invalid_chars = !invalid_chars.is_empty();
-    
+
     // If there are invalid characters, the pattern is impossible to find
     if has_invalid_chars {
         return PatternEstimate {
@@ -47,7 +47,7 @@ pub fn estimate_pattern(pattern: &str, is_start: bool) -> PatternEstimate {
             invalid_chars,
         };
     }
-    
+
     let pattern_length = pattern.len() as f64;
 
     // Calculate the base number of attempts based on the matching location.
@@ -102,9 +102,9 @@ pub fn format_time(seconds: f64) -> String {
 /// This displays the pattern, the estimated attempts needed, and the time estimates for two different speeds.
 pub fn print_estimate(pattern: &str, is_start: bool) {
     let estimate = estimate_pattern(pattern, is_start);
-    
+
     println!("\nPattern: \"{}\"", pattern);
-    
+
     if estimate.has_invalid_chars {
         println!("WARNING: Pattern contains invalid Base58 characters:");
         println!("  Invalid characters: {}", estimate.invalid_chars.iter().collect::<String>());
@@ -119,7 +119,7 @@ pub fn print_estimate(pattern: &str, is_start: bool) {
 }
 
 /// Wrapper function that prints the estimate and difficulty header
-/// 
+///
 /// This is a convenience function called from main.rs
 pub fn estimate_and_print(pattern: &str, is_start: bool) {
     // Print header only for the first pattern


### PR DESCRIPTION
Fix: Allow uppercase 'L' in Base58 pattern validation

Problem: The application was incorrectly rejecting uppercase 'L' as an invalid Base58 character, even though 'L' is valid in Base58 encoding. Only lowercase 'l' should be excluded to avoid confusion with uppercase 'I'.

Error encountered:
$ ./ergo-vanitygen -p L -e
Error: Invalid character 'l' in pattern 'l' at position 1.

Root Cause: The issue was in the order of operations in PatternMatcher::new(): 1) User provides pattern L (valid Base58), 2) Pattern gets converted to lowercase l (case-insensitive matching), 3) Base58 validation runs on l and rejects it as invalid, 4) Validation fails incorrectly.

Solution: Fixed Base58 character validation by updating is_base58_char() in both matcher.rs and estimator.rs to use explicit character ranges that properly exclude only 0, O, I, and l. Reordered validation logic to occur before case conversion in the constructor, ensuring original user input is validated correctly. Preserved functionality for case-insensitive matching.

Files Changed: src/matcher.rs (fixed character validation and moved Base58 validation to constructor), src/estimator.rs (fixed character validation for consistency).

Testing: ./ergo-vanitygen -p L -e now works correctly, all existing functionality preserved, invalid characters still properly rejected.